### PR TITLE
Add support for Symfony 4/5 and remove Symfony 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,13 @@
     "description": "Add a Boris repl command to the Symfony console",
     "require": {
         "php": ">=5.3.2",
-        "symfony/console": "~2 | ~3",
-        "symfony/framework-bundle": "~2 | ~3",
+        "symfony/console": ">=3",
+        "symfony/framework-bundle": ">=3",
         "d11wtq/boris": "~1.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7"
+        "phpunit/phpunit": "~6",
+        "mockery/mockery": "~1"
     },
     "autoload": {
         "psr-4": { "": "src" }

--- a/src/NinetyNine/Bundle/ReplBundle/Command/ReplCommand.php
+++ b/src/NinetyNine/Bundle/ReplBundle/Command/ReplCommand.php
@@ -3,15 +3,24 @@
 namespace NinetyNine\Bundle\ReplBundle\Command;
 
 use Boris\Boris;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Start a Boris (https://github.com/d11wtq/boris) REPL
  */
-class ReplCommand extends ContainerAwareCommand
+class ReplCommand extends Command
 {
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        parent::__construct();
+    }
+
     protected function configure()
     {
         $this
@@ -25,12 +34,10 @@ class ReplCommand extends ContainerAwareCommand
         $application->setCatchExceptions(false);
         $application->setAutoExit(false);
 
-        $container = $this->getContainer();
-
         $boris = new Boris('php> ');
         $boris->setLocal(array(
-            'container' => $container,
-            'kernel' => $container->get('kernel'),
+            'container' => $this->container,
+            'kernel' => $this->container->get('kernel'),
         ));
         $boris->start();
     }

--- a/src/NinetyNine/Bundle/ReplBundle/DependencyInjection/ReplExtension.php
+++ b/src/NinetyNine/Bundle/ReplBundle/DependencyInjection/ReplExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace NinetyNine\Bundle\ReplBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class ReplExtension extends Extension
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/NinetyNine/Bundle/ReplBundle/Resources/config/services.yml
+++ b/src/NinetyNine/Bundle/ReplBundle/Resources/config/services.yml
@@ -1,0 +1,7 @@
+services:
+  _defaults:
+    public: true
+    autowire: true
+    autoconfigure: true
+
+  NinetyNine\Bundle\ReplBundle\Command\ReplCommand: ~

--- a/src/NinetyNine/Bundle/ReplBundle/Tests/Command/ReplCommandTest.php
+++ b/src/NinetyNine/Bundle/ReplBundle/Tests/Command/ReplCommandTest.php
@@ -2,14 +2,18 @@
 
 namespace NinetyNine\Bundle\ReplBundle\Tests\Commands;
 
+use Mockery;
 use NinetyNine\Bundle\ReplBundle\Command\ReplCommand;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ReplCommandTest extends TestCase
 {
     public function testCommand()
     {
         // There's no useful way to test this; just check that it loads and compiles
-        new ReplCommand();
+        $container = Mockery::mock(ContainerInterface::class);
+        $command = new ReplCommand($container);
+        $this->assertNotEmpty($command);
     }
 }

--- a/src/NinetyNine/Bundle/ReplBundle/Tests/ReplBundleTest.php
+++ b/src/NinetyNine/Bundle/ReplBundle/Tests/ReplBundleTest.php
@@ -3,13 +3,14 @@
 namespace NinetyNine\Bundle\ReplBundle\Tests;
 
 use NinetyNine\Bundle\ReplBundle\ReplBundle;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class ReplBundleTest extends TestCase
 {
     public function testBundle()
     {
         // There's no useful way to test this; just check that it loads and compiles
-        new ReplBundle();
+        $bundle = new ReplBundle();
+        $this->assertNotEmpty($bundle);
     }
 }


### PR DESCRIPTION
This adds support for both Symfony 4 & 5, while removing support for Symfony 2.

The command provided by this package needed to be explicitly exposed as a public service for Symfony 4.

`ContainerAwareCommand` is removed in Symfony 5. Instead the container is injected into the command so it is available for use by the Boris repl.