### PR TITLE
Abandon package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 REPL bundle
 ===========
 
+---
+
+**Important**: This bundle is no longer under active development. Consider using [PsyshBundle][psyshbundle] as an alternative.
+
+---
 
 Provides a `repl` command for the Symfony console, powered by [Boris][boris].
-
 
 Installation
 ------------
@@ -33,7 +37,6 @@ class AppKernel extends Kernel
     }
 }
 ```
-
 
 Usage
 -----
@@ -65,7 +68,7 @@ If you see these errors, you'll need to edit your PHP CLI configuration
 (typically found at `/etc/php5/cli/php.ini`) to allow invocation of the named
 functions.
 
-
+ [psyshbundle]: https://github.com/theofidry/PsyshBundle
  [boris]: https://github.com/d11wtq/boris
  [composer]: http://getcomposer.org/
  [pcntl]: http://www.php.net/manual/en/book.pcntl.php

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "99designs/repl-bundle",
     "description": "Add a Boris repl command to the Symfony console",
+    "abandoned": "theofidry/psysh-bundle",
     "require": {
         "php": ">=5.3.2",
         "symfony/console": ">=3",


### PR DESCRIPTION
This PR adds some metadata to the composer.json and updates the README to suggest that this package is abandoned and no longer under active development.

It points to https://github.com/theofidry/PsyshBundle as an alternative, which is both being actively developed and relies on [PsySH](https://psysh.org/), a modern PHP REPL library, rather than Boris, which [hasn't had a release in 6+ years](https://github.com/borisrepl/boris/releases/tag/v1.0.10).